### PR TITLE
Prepare for publishing to NPX

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,32 +91,52 @@ Below are instructions on how to manually integrate the PinMeTo MCP with Claude 
 4. **Configure Claude Desktop:**
    - Open your `claude_desktop_config.json` file. You can go to Preferences → Developer → Edit Config in the Claude Desktop Client. Or use on Mac:
 
-     ```bash
-     code ~/Library/Application\ Support/Claude/claude_desktop_config.json
-     ```
+    ```bash
+    code ~/Library/Application\ Support/Claude/claude_desktop_config.json
+    ```
 
-   - Add the following MCP server configuration:
+   - Add the following MCP server configuration (with npx)
 
-     ```json
-     {
-       "mcpServers": {
-         "PinMeTo": {
-           "command": "/absolute/path/to/node",
-           "args": ["/absolute/path/to/project/build/index.js"],
-           "env": {
-             "PINMETO_API_URL": "",
-             "PINMETO_ACCOUNT_ID": "",
-             "PINMETO_APP_ID": "",
-             "PINMETO_APP_SECRET": ""
-           }
-         }
-       }
-     }
-     ```
+    ```json
+    {
+    "mcpServers": {
+        "PinMeTo": {
+            "command": "npx",
+            "args": ["-y", "pinmeto-location-mcp"],
+            "env": {
+                "PINMETO_ACCOUNT_ID": "",
+                "PINMETO_APP_ID": "",
+                "PINMETO_APP_SECRET": ""
+            }
+        }
+    }
 
-   - Use absolute paths for both Node and your project:
-     - Node path: `which node`
-     - Project path: `pwd`
+    }
+
+    ```
+
+    - Add the following MCP server configuration (with node)
+
+        ```json
+        {
+        "mcpServers": {
+            "PinMeTo": {
+            "command": "/absolute/path/to/node",
+            "args": ["/absolute/path/to/project/build/index.js"],
+            "env": {
+                "PINMETO_API_URL": "",
+                "PINMETO_ACCOUNT_ID": "",
+                "PINMETO_APP_ID": "",
+                "PINMETO_APP_SECRET": ""
+            }
+            }
+        }
+        }
+        ```
+
+- Use absolute paths for both Node and your project:
+  - Node path: `which node`
+  - Project path: `pwd`
 
 5. **Get your PinMeTo API credentials:**
    - Visit [PinMeTo Account Settings](https://places.pinmeto.com/account-settings/pinmeto/api/v3) and fill in the environment variables above.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": "0.2",
-  "name": "pinmeto-location-mcp",
+  "name": "@pinmeto/pinmeto-location-mcp",
   "display_name": "PinMeTo Location MCP",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Connect with your PinMeTo location data.",
   "long_description": "The PinMeTo MCP Server enables seamless integration between the PinMeTo platform and AI agents such as Claude LLM, allowing users to interact with their location data and business insights through natural language. This server exposes a suite of tools that let you retrieve, analyze, and summarize data from multiple sources—including Google, Facebook, and Apple—covering metrics such as impressions, clicks, ratings, and more.",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -831,6 +831,7 @@
       "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -1420,6 +1421,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1985,6 +1987,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2540,6 +2543,7 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2748,6 +2752,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "pinmeto-location-mcp",
-  "version": "1.0.1",
+  "name": "@pinmeto/pinmeto-location-mcp",
+  "version": "1.0.2",
   "description": "PinMeTo Location MCP",
   "main": "index.js",
   "scripts": {
+    "prepare": "npm run build",
+    "release": "npm publish ./build",
     "build": "node manifest.js && tsc",
     "start": "NODE_ENV=development node build/index.js",
     "format": "prettier --write \"**/*.{js,ts}\"",
@@ -17,6 +19,9 @@
   "keywords": [
     "mcp"
   ],
+  "bin": {
+    "pinmeto-location-mcp": "./build/index.js"
+  },
   "author": "pinmeto",
   "license": "MIT",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import dotenv from 'dotenv';
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -26,9 +26,11 @@ import {
 import { getAllAppleInsights, getAppleLocationInsights } from './tools/networks/apple';
 import { analyzeLocationPrompt, summarizeAllInsightsPrompt } from './prompts';
 import { Configs, getConfigs } from './configs';
-import packageJson from '../package.json';
+
 import { ServerOptions } from '@modelcontextprotocol/sdk/server';
 
+const PACKAGE_NAME = '@pinmeto/pinmeto-location-mcp';
+const PACKAGE_VERSION = '1.0.2';
 const TOKEN_CACHE_SECONDS = 59 * 60;
 
 export class PinMeToMcpServer extends McpServer {
@@ -120,7 +122,7 @@ export class PinMeToMcpServer extends McpServer {
 export function createMcpServer() {
   const serverInfo = {
     name: 'PinMeTo Location MCP',
-    version: packageJson.version,
+    version: PACKAGE_VERSION,
     capabilities: {
       prompts: {},
       resources: {},
@@ -133,7 +135,7 @@ export function createMcpServer() {
     mcpServer.server.setRequestHandler(InitializeRequestSchema, async request => {
       // Set a custom User-Agent for all axios requests
       axios.defaults.headers.common['User-Agent'] =
-        `${request.params.clientInfo.name}/${request.params.clientInfo.version} ${packageJson.name}-${packageJson.version} (${os.type()}; ${os.arch()}; ${os.release()})`;
+        `${request.params.clientInfo.name}/${request.params.clientInfo.version} ${PACKAGE_NAME}-${PACKAGE_VERSION} (${os.type()}; ${os.arch()}; ${os.release()})`;
 
       const requestedVersion = request.params.protocolVersion;
       const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This pull request updates the PinMeTo Location MCP package to improve its distribution and integration options, and standardizes its metadata and versioning. The most important changes include renaming the package to use the scoped NPM name, adding CLI support, and updating documentation for new integration methods.

**Package metadata and distribution:**

* Renamed the package to `@pinmeto/pinmeto-location-mcp` and bumped the version to `1.0.2` in both `package.json` and `manifest.json` for consistency with NPM conventions. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R8) [[2]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L3-R5)
* Added a `bin` entry to `package.json` to support running the MCP server as a CLI tool, and included a build script and release command for easier publishing. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R22-R24) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R8)

**Integration and documentation improvements:**

* Updated the `README.md` to show how to integrate the MCP server using both `npx` and `node`, reflecting the new CLI support and providing clearer setup instructions.
* Added a Node.js shebang (`#!/usr/bin/env node`) to `src/index.ts` to enable direct CLI execution.

**Codebase consistency:**

* Standardized usage of the package name and version in `src/mcp_server.ts` by introducing constants and replacing previous imports from `package.json`. This ensures consistent metadata in server info and HTTP headers. [[1]](diffhunk://#diff-ba1794eb9554418f30944e1359e47cd7a36f08d870a5b9ff46f7ab3082590eddL29-R33) [[2]](diffhunk://#diff-ba1794eb9554418f30944e1359e47cd7a36f08d870a5b9ff46f7ab3082590eddL123-R125) [[3]](diffhunk://#diff-ba1794eb9554418f30944e1359e47cd7a36f08d870a5b9ff46f7ab3082590eddL136-R138)