### PR TITLE
fix: unblock @modelcontextprotocol/sdk upgrades past 1.26.0 (nodenext)

### DIFF
--- a/.changeset/unblock-mcp-sdk-upgrade.md
+++ b/.changeset/unblock-mcp-sdk-upgrade.md
@@ -1,0 +1,23 @@
+---
+"@pinmeto/pinmeto-location-mcp": patch
+---
+
+Unblock `@modelcontextprotocol/sdk` upgrades (now on 1.29.0).
+
+The build was pinned to SDK 1.26.0 because newer versions exposed the bare
+`@modelcontextprotocol/sdk/server` subpath with an unconditional ESM `types`
+entry, which `tsc` under the older `Node16` module resolution rejected with
+TS1479 ("CommonJS module cannot `require` an ECMAScript module").
+
+**Decision: migrate module resolution to `nodenext`.** `tsconfig` `module` and
+`moduleResolution` are now `nodenext` instead of `Node16`. The newer resolution
+algorithm correctly applies the package's CommonJS `require` condition for the
+bare subpath, so the import resolves without error. The package remains
+CommonJS (no `"type": "module"`) — `nodenext` keys module format off
+`package.json` `"type"`, so emit is still `require(...)` and no entrypoint /
+`__dirname` plumbing changes were needed. `nodenext` floats to current Node
+resolution semantics, so this also future-proofs against later SDK subpath
+changes (unlike `Node16`, which is pinned to Node 16-era behavior).
+
+The `ServerOptions` import is also tightened to `import type` (it is used only
+as a type annotation), erasing it at compile time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.16.0",
         "zod": "^3.25.76"
       },
@@ -2307,9 +2307,9 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/PinMeTo/pinmeto-location-mcp#readme",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.16.0",
     "zod": "^3.25.76"
   },

--- a/src/mcp_server.ts
+++ b/src/mcp_server.ts
@@ -27,7 +27,7 @@ import {
 import { getAppleInsights } from './tools/networks/apple';
 import { Configs, getConfigs } from './configs';
 
-import { ServerOptions } from '@modelcontextprotocol/sdk/server';
+import type { ServerOptions } from '@modelcontextprotocol/sdk/server';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as {
   name: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

Fixes #42. The build was stuck on `@modelcontextprotocol/sdk@1.26.0` because newer versions tripped `tsc` with TS1479 under the `Node16` module resolution. This bumps the SDK to **1.29.0** and migrates module resolution to **`nodenext`**.

## Root cause

The SDK's `./server` export entry advertises an unconditional `"types": "./dist/esm/server/index.d.ts"` (ESM declaration). Under `moduleResolution: "Node16"`, `tsc` read that ESM `.d.ts`, classified the bare subpath as ESM, and refused to emit a `require()` for it from this CommonJS package:

```
src/mcp_server.ts(30,31): error TS1479: The current file is a CommonJS module whose imports
will produce 'require' calls; however, the referenced file is an ECMAScript module ...
```

## Fix: migrate to `nodenext`

`tsconfig` `module`/`moduleResolution` → `nodenext`. The newer algorithm correctly applies the package's CommonJS `require` condition for the bare subpath, so the import resolves without error.

- The package **stays CommonJS** — `nodenext` keys module format off `package.json` `"type"` (absent → CommonJS). Emit is still `require(...)`; no entrypoint, `__dirname`, or `readFileSync` plumbing changes were needed.
- `nodenext` floats to current Node resolution semantics, so this also future-proofs against later SDK subpath changes (unlike `Node16`, pinned to Node 16-era behavior).
- `ServerOptions` is tightened to `import type` (used only as a type annotation), so it erases at compile time.

### Why `nodenext` over the one-line `import type` workaround

A surgical alternative existed (keep `Node16`, import `ServerOptions` from the explicit `/server/index.js` wildcard subpath). We chose `nodenext` deliberately: it's the forward-looking resolution mode, fixes the bare public import without relying on the `./*` exports wildcard, and unblocks future SDK subpath changes generally rather than patching one import site. A full ESM migration (`type: module`) was **not** needed — `nodenext` solves it while the package stays CommonJS.

## Verification

- `npm run build` passes on SDK 1.29.0 under `nodenext`
- `npm test` passes (236/236)
- Emitted JS still uses `require()` (package remains CommonJS); the type import is erased
- Server starts over stdio, responds to `initialize`, lists all 12 tools

## Acceptance criteria

- [x] SDK upgradable to >= 1.29.0
- [x] `npm run build` passes
- [x] `npm test` passes (236 tests)
- [x] MCP server starts over stdio and tools respond
- [x] Decision documented (changeset + this PR): migrate to `nodenext`, package stays CommonJS

🤖 Generated with [Claude Code](https://claude.com/claude-code)