### PR TITLE
fix: prevent -32602 in pinmeto_get_google_ratings for zero-review stores

### DIFF
--- a/.changeset/google-ratings-zero-review-32602.md
+++ b/.changeset/google-ratings-zero-review-32602.md
@@ -1,0 +1,5 @@
+---
+"@pinmeto/pinmeto-location-mcp": patch
+---
+
+Fix `-32602` output-validation crash in `pinmeto_get_google_ratings`. A single-store query for a period with no reviews returned `averageRating: 0`, which the ratings output schema rejected (`averageRating` had a `min(1)` floor), killing the call. The floor is relaxed to `min(0)` so a zero-review store returns a clean summary (`averageRating: 0, totalReviews: 0`) instead of failing. The all-locations path was unaffected because it omits stores with no reviews.

--- a/src/schemas/output.ts
+++ b/src/schemas/output.ts
@@ -222,7 +222,12 @@ export const KeywordDataSchema = z
  */
 export const RatingsSummarySchema = z
   .object({
-    averageRating: z.number().min(1).max(5).optional().describe('Average rating (1-5)'),
+    averageRating: z
+      .number()
+      .min(0)
+      .max(5)
+      .optional()
+      .describe('Average rating (1-5); 0 when the location has no reviews in range'),
     totalReviews: z.number().nonnegative().optional().describe('Total number of reviews'),
     distribution: z
       .record(z.string(), z.number().nonnegative())

--- a/tests/mcp_server.test.ts
+++ b/tests/mcp_server.test.ts
@@ -2740,6 +2740,49 @@ describe('Consolidated Network Tools', () => {
     });
   });
 
+  describe('pinmeto_get_google_ratings', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      vi.mocked(axios.post).mockImplementation((url: string) => {
+        if (url.includes('/oauth/token')) {
+          return Promise.resolve({ data: { access_token: testAccessToken } });
+        }
+        return Promise.reject(new Error('Not found'));
+      });
+      vi.mocked(axios.get).mockImplementation((url: string, { headers }: any) => {
+        if (headers['Authorization'] !== `Bearer ${testAccessToken}`) {
+          return Promise.reject(new Error('Unauthorized'));
+        }
+        // A single store with no reviews in the requested period.
+        if (url.includes('/ratings/google/empty-store')) {
+          return Promise.resolve({ data: [] });
+        }
+        return Promise.reject(new Error('Not found'));
+      });
+    });
+
+    it('should return a zero summary rather than a -32602 when a single store has no reviews', async () => {
+      const response = await callNetworkTool('pinmeto_get_google_ratings', {
+        storeId: 'empty-store',
+        from: '2024-01-01',
+        to: '2024-12-31',
+        forceRefresh: true
+      });
+
+      // Before the fix, the summary's averageRating of 0 tripped the output
+      // schema's .min(1) floor and the SDK rejected the response with an
+      // output-validation error (JSON-RPC -32602).
+      expect(response.error).toBeUndefined();
+      expect(response.result).toBeDefined();
+      expect(response.result.isError).toBeFalsy();
+
+      const data = response.result.structuredContent.data;
+      expect(data.averageRating).toBe(0);
+      expect(data.totalReviews).toBe(0);
+      expect(data.distribution).toEqual({});
+    });
+  });
+
   describe('pinmeto_get_google_review_insights', () => {
     beforeEach(() => {
       vi.clearAllMocks();


### PR DESCRIPTION
## What

`pinmeto_get_google_ratings` crashed with an MCP `-32602` output-validation error when queried for a **single store over a period with no reviews**.

```
MCP error -32602: Output validation error: Invalid structured content for tool
pinmeto_get_google_ratings: Number must be greater than or equal to 1 at data.averageRating
```

## Root cause

- `aggregateReviewsToRatings()` returns `{ averageRating: 0, totalReviews: 0, distribution: {} }` for a single store with no reviews (`src/tools/networks/google.ts:412`).
- `RatingsSummarySchema.averageRating` had a `.min(1)` floor (`src/schemas/output.ts`), so the present `0` failed validation. `.optional()` didn't help — it only permits the key to be **absent**, not `0`.

The all-locations path was unaffected: it builds its array only from stores that actually have ratings, so a zero-review store is simply omitted and no `0` is ever emitted. Only the single-store path crashed.

This is the same `-32602` output-validation class of bug that was previously fixed in `pinmeto_get_google_review_insights` (which got a zero-review guard); the ratings tool never got equivalent treatment.

## Fix

Relax the `averageRating` floor from `.min(1)` to `.min(0)` so a zero-review store returns a clean summary (`averageRating: 0, totalReviews: 0, distribution: {}`) instead of failing. This preserves the tool's response shape — `totalReviews: 0` already signals "no reviews" — rather than retrofitting the `data: null` shape from a sibling tool. `LocationRatingsSummarySchema` extends `RatingsSummarySchema`, so the array variant inherits the change.

## Testing

- Added a regression test (`pinmeto_get_google_ratings > should return a zero summary rather than a -32602 when a single store has no reviews`) that mocks an empty single-store ratings response and asserts a clean summary instead of an error. Confirmed it fails with the exact `-32602` message before the fix and passes after.
- Full suite green: 234 tests pass. Build clean.

## How it was found

Surfaced during a manual v4.0.0 test pass against the live dev server: `pinmeto_get_google_ratings` for store `1337` over 2026-04-01→2026-06-30 (a quarter in which that store had no Google reviews) died with `-32602`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)